### PR TITLE
Separate tag and repository variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ You can easily register smuggler as a service by using
 First build the container:
 
 ```
-# A repository in dockerhub or other docker repository
-export SMUGGLER_DOCKER_TAG=<...your_docker_repository...>
+# You want to replece it with your own Docker repository. 
+export SMUGGLER_DOCKER_REPOSITORY=redfactorlabs/concourse-smuggler-resource
+# A Docker tag for that container
+export SMUGGLER_DOCKER_TAG=ubuntu-14.04
 ./scripts/build-docker
 ```
 
@@ -33,7 +35,7 @@ resource_types:
   type: docker-image
   source:
     # Replace the url
-    repository: <...your_docker_repository...>
+    repository: redfactorlabs/concourse-smuggler-resource:ubuntu-14.04
 ```
 
 Modify `Dockerfile` to build your own container image bundled with smuggler.
@@ -45,7 +47,7 @@ See below for more details.
 
 ## Source configuration and tasks
 
-Once you `smuggler` is defined as a resource type, you only need to define
+Once your `smuggler` is defined as a resource type, you only need to define
 your resource using this structure:
 
 ```

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -1,12 +1,23 @@
 #!/bin/bash
-set -e
+set -eu
+SMUGGLER_DOCKER_TAG="${SMUGGLER_DOCKER_TAG:-ubuntu-14.04}"
+SMUGGLER_DOCKER_REPOSITORY="${SMUGGLER_DOCKER_REPOSITORY:-redfactorlabs/concourse-smuggler-resource}"
+SMUGGLER_DOCKER_IMAGE="${SMUGGLER_DOCKER_REPOSITORY}:${SMUGGLER_DOCKER_TAG}"
 
-SMUGGLER_DOCKER_TAG=${SMUGGLER_DOCKER_TAG:-redfactorlabs/concourse-smuggler-resource:ubuntu-14.04}
+if ! which go > /dev/null; then
+  echo "You need GO binary to run this script."
+  exit 1
+fi
 
-go install github.com/tools/godep
+if ! which godep > /dev/null; then
+  echo "Installing godep..."
+  go get github.com/tools/godep
+fi
+
+echo "Restoring dependencies..."
 godep restore
 ./scripts/test
 ./scripts/build
 
-docker build -t ${SMUGGLER_DOCKER_TAG} .
-docker push ${SMUGGLER_DOCKER_TAG}
+docker build -t "${SMUGGLER_DOCKER_IMAGE}" .
+docker push "${SMUGGLER_DOCKER_IMAGE}"


### PR DESCRIPTION
# What

To make it more easy to understand I split SMUGGLER_DOCKER_TAG variable into two
separate ones to improve readability.

Also some minor beautifying of the build script and related changes to README.
# How to test

Run:

```
export SMUGGLER_DOCKER_REPOSITORY="your_docker_repo/smuggler"
export SMUGGLER_DOCKER_TAG="test"
./scripts/build-docker
```
- Check if `your_docker_repo/smuggler:test` has been pushed to your repo.
- check if Readme changes makes sense 
