### PR TITLE
Deploy releases based on tags from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
-sudo: false # Enables container based builds
-
+sudo: false
 language: go
+
 go:
 - 1.8
 
 install:
-  - export PATH=$PATH:$HOME/gopath/bin
-  - go get github.com/tools/godep
-  - godep restore
+- export PATH=$PATH:$HOME/gopath/bin
+- go get github.com/tools/godep
+- godep restore
 
 script:
- - ./scripts/test
+- "./scripts/test"
+- "./scripts/build"
+
+deploy:
+  provider: releases
+  file_glob: true
+  file: "assets/smuggler-*-*"
+  api_key:
+    secure: yjY98eo4+2tyGnGblZDyY6lBqXOkPhFXAB00LcIuymTu+4/ApwiqvvBNvbU4qcqTrl/ap+L9AN2oHj2ThUb059639tO7gBeENt1kQZSEeB9qKrWpI9VE8gwL6wvwbwWct0QouYa/2vjSiTVIQuw9h1hQz7L41FqVmgx7eZi0/9WxORu7lOwy616zUgvZvIVLo00ydK6NggIs+4xYlvDV4DiFTwSb9iG9DKt+/5gRKIBDHrFcTfWTq0dLbDI5JVH8TNzft519qqQ/lwGm1CFvwq1zXdyfDhWA3vLpJmMqQfSYgxZGoDul/HFppW02W/Tjb/bVSAalrD+rx4OsFDqUDZ6nHDrfb43fJOv+69ZPrTFpgx6lNNuO+dGRnYpg4aCw8EtmW05Smm/9iP0W0qX+MbGOC9yVH4ps+Iia+gnJqrdw0wXzdGKlauIV5MadZ9S0DNdOio95TwNerAYesMHMz2BluJQpsvnRdvwI49V1vo9SEVIhyt9oKr3ZiTuXhUNISvEdlJMp5UQWk/MpimHcD8Fmo49aQOQwdtkSgM6wBqooMwK98MibMkWHaMJmelUoY0nv/JHzux2aTL1rG4ldSLT567woTVRg4JW2UCIyXA7TFfNlo9BVoCfReL2VSbVSCYiH02SkvQdt36YHCDpqKKKbymZY2RjXYs9J3qgv3cU=
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false # Enables container based builds
 
 language: go
 go:
- - 1.6
+- 1.8
 
 install:
   - export PATH=$PATH:$HOME/gopath/bin

--- a/scripts/build
+++ b/scripts/build
@@ -3,8 +3,15 @@ set -e
 
 mkdir -p assets
 export CGO_ENABLED=1
+
 godep go build -o assets/smuggler ./cmd/smuggler
-export GOOS=linux
-export GOARCH=amd64
-godep go build -o assets/smuggler-linux-amd64 ./cmd/smuggler
+
+for GOOS in darwin linux; do
+  for GOARCH in 386 amd64; do
+    echo "Building $GOOS-$GOARCH"
+    export GOOS=$GOOS
+    export GOARCH=$GOARCH
+	godep go build -o assets/smuggler-$GOOS-$GOARCH ./cmd/smuggler
+  done
+done
 

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -7,5 +7,6 @@ go install github.com/tools/godep
 godep restore
 ./scripts/test
 ./scripts/build
+
 docker build -t ${SMUGGLER_DOCKER_TAG} .
 docker push ${SMUGGLER_DOCKER_TAG}


### PR DESCRIPTION
Travis will upload a new release for every tag in the repository.

We use Use a token from a dedicated user that has been configured using:

    travis setup releases --org -r redfactorlabs/concourse-smuggler-resource

We build multiple releases for linux and darwin

We also test and update to golang 1.8