### PR TITLE
New examples: smuggler-credstash-wrapper and smuggler-credstash

### DIFF
--- a/examples/credstash/Dockerfile
+++ b/examples/credstash/Dockerfile
@@ -1,0 +1,26 @@
+FROM alpine:3.5
+
+ADD assets/smuggler-linux-amd64 /opt/resource/smuggler
+
+RUN ln /opt/resource/smuggler /opt/resource/check && \
+    ln /opt/resource/smuggler /opt/resource/in && \
+    ln /opt/resource/smuggler /opt/resource/out
+
+RUN apk -U add --no-cache \
+        python \
+        py-pip \
+        openssl \
+        jq \
+    && apk -U add --no-cache -t credstash-build-deps \
+        python-dev \
+        libffi-dev \
+        build-base \
+        openssl-dev \
+    && pip install credstash  \
+    && apk del credstash-build-deps  \
+    && rm -rf /var/cache/apk/*
+
+# Add the config file for this resource
+ADD ./smuggler.yml /opt/resource/
+
+

--- a/examples/credstash/Makefile
+++ b/examples/credstash/Makefile
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+DOCKER_HUB_ACCOUNT=redfactorlabs
+
+all: build push
+
+clean:
+	rm -rf assets
+
+assets/smuggler:
+	cd ../../ \
+	  && ./scripts/build
+	cp ../../assets/smuggler-linux-amd64 ./assets
+
+get_assets: assets/smuggler
+
+build: get_assets
+	docker build .  -t $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-resource
+
+push:
+	docker push $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-resource
+

--- a/examples/credstash/README.md
+++ b/examples/credstash/README.md
@@ -1,0 +1,105 @@
+# Example: credstash resource
+
+Proof of concept to get credentials from credstash
+
+This resource uses [smuggler concourse resource](https://github.com/redfactorlabs/concourse-smuggler-resource)
+to get credentials from [credstash store](https://github.com/fugue/credstash)
+
+Inspired on the code from https://hub.docker.com/r/paroxp/concourse-credstash-resource/
+
+
+## Usage example
+
+You must first configure a [credstash store](https://github.com/fugue/credstash)
+using credstash, unicreds, or a [terraform configuration](https://github.com/keymon/tf-credstash).
+
+You must then populate the credstash store with variables:
+
+```
+unicreds \
+  -r eu-west-1 \
+  -t credstash-concourse-demo \
+  put-file \
+  -k alias/credstash-concourse-demo \
+  github.id_rsa \
+  ~/.ssh/concourse-demo
+```
+
+Define the new resource type:
+
+```
+resource_types:
+- name: smuggler-credstash
+  type: docker-image
+  source:
+    repository: redfactorlabs/smuggler-credstash-resource
+```
+
+> **NOTE:** If you are going to use this resources **I highly recommend** push your
+> own copy to your own docker repository. This image might change.
+
+And then define the resource these parameters:
+
+  * `credstash_table`: optional, credstash store dynamo table
+  * `credstash_region`: AWS region of the credstash store. Default: `eu-west-1`
+  * `credstash_aws_access_key_id`, `credstash_aws_secret_access_key` and `credstash_aws_session_token`: AWS credentials. Not needed when using IAM instance profiles
+  * `credstash_aws_iam_profile`: optional, use IAM instance profile (see below)
+
+For example:
+
+```yaml
+- name: credstash-aws-creds
+  type: smuggler-credstash
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_key: alias/credstash-concourse-demo
+    credstash_aws_access_key_id: {{credstash_aws_access_key_id}}
+    credstash_aws_secret_access_key: {{credstash_aws_secret_access_key}}
+    credstash_aws_session_token: {{credstash_aws_session_token}}
+```
+### Get secrets
+
+Finally you can consume the credentials by passing a parameters `secrets` with the list of secrets to query:
+
+```
+- get: credstash-aws-creds
+  params:
+    secrets:
+    - example.key.date
+    - deploy.test-server.TOKEN
+    - github.id_rsa
+
+```
+
+
+The secrets will be stored in files named as the key value, eg `./credstash-aws-creds/deploy.test-server.TOKEN`
+
+### Set secrets
+
+In order to set the value of secrets, you can create a task that populates files named as the key of the secret and with the value as content:
+
+```
+- put: credstash-aws-creds
+  params:
+    secrets_dir: new_secrets
+```
+
+## Using credstash with IAM instance profiles
+
+One way of using this resource is [granting your Concourse workers with a IAM profile](https://bosh.io/docs/aws-iam-instance-profiles.html)
+that would allow access the credstash without having to pass any credentials at all to the pipelines.
+
+In this branch there is an example of how to configure the store and the profile: https://github.com/keymon/tf-credstash/tree/implement_iam_profile
+
+You only need to pass the option  `aws_iam_profile: true` as to the resource:
+
+```
+- name: credstash-iam-profile
+  type: smuggler-credstash
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_key: alias/credstash-concourse-demo
+    credstash_aws_iam_profile: true
+```
+
+

--- a/examples/credstash/pipeline.yml
+++ b/examples/credstash/pipeline.yml
@@ -1,0 +1,103 @@
+# credstash -r eu-west-1 -t credstash-concourse-demo put -k alias/credstash-concourse-demo deploy.test-server.TOKEN "$(uuidgen)"
+# credstash -r eu-west-1 -t credstash-concourse-demo put -k alias/credstash-concourse-demo example.key.date "$(date)"
+# credstash -r eu-west-1 -t credstash-concourse-demo put-file -k alias/credstash-concourse-demo github.id_rsa ~/.ssh/concourse-demo
+#
+# fly -t demo set-pipeline \
+#   -p smuggler-credstash \
+#   -c pipeline.yml \
+#   --var "credstash_aws_access_key_id=${AWS_ACCESS_KEY_ID}" \
+#   --var "credstash_aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" \
+#   --var "credstash_aws_session_token=${AWS_SESSION_TOKEN}" \
+#
+---
+resource_types:
+- name: smuggler-credstash
+  type: docker-image
+  source:
+    repository: redfactorlabs/smuggler-credstash-resource
+
+resources:
+
+- name: credstash-aws-creds
+  type: smuggler-credstash
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_key: alias/credstash-concourse-demo
+    credstash_aws_access_key_id: {{credstash_aws_access_key_id}}
+    credstash_aws_secret_access_key: {{credstash_aws_secret_access_key}}
+    credstash_aws_session_token: {{credstash_aws_session_token}}
+
+- name: credstash-iam-profile
+  type: smuggler-credstash
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_key: alias/credstash-concourse-demo
+    credstash_aws_iam_profile: true
+
+jobs:
+- name: credstash-aws-creds
+  serial: true
+  plan:
+  - get: credstash-aws-creds
+    params:
+      secrets:
+      - example.key.date
+      - deploy.test-server.TOKEN
+      - github.id_rsa
+
+- name: credstash-iam-profile
+  serial: true
+  plan:
+  - get: credstash-iam-profile
+    params:
+      secrets:
+      - example.key.date
+      - deploy.test-server.TOKEN
+      - github.id_rsa
+  - task: display_secrets
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+        - name: credstash-iam-profile
+        outputs:
+        - name: new_secrets
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            # Files
+            find .
+            for f in credstash-*/*; do
+              echo "Printing $f"
+              echo "-------- 8< -------- 8< -------- 8< -------- 8< --------"
+              cat $f
+              echo "-------- 8< -------- 8< -------- 8< -------- 8< --------"
+              echo
+            done
+
+            # Trying the shell helper
+            eval $(credstash-iam-profile/credstash.sh)
+            echo "\$example_key_date='$example_key_date'"
+            echo "\$github_id_rsa='$github_id_rsa'"
+            echo "\$deploy_test_server_TOKEN='$deploy_test_server_TOKEN'"
+
+            # Trying the shell helper for terraform
+            eval $(credstash-iam-profile/credstash-terraform.sh)
+            env | grep TF_VAR
+
+            # Adding a new secret
+            mkdir -p new_secrets
+            date > new_secrets/example.key.date
+  - put: credstash-iam-profile
+    params:
+      secrets_dir: new_secrets
+
+
+
+

--- a/examples/credstash/smuggler.yml
+++ b/examples/credstash/smuggler.yml
@@ -1,0 +1,57 @@
+commands:
+  check: |
+    if [ "${SMUGGLER_credstash_aws_iam_profile:-}" != "true" ]; then
+      export AWS_ACCESS_KEY_ID="${SMUGGLER_credstash_aws_access_key_id}"
+      export AWS_SECRET_ACCESS_KEY="${SMUGGLER_credstash_aws_secret_access_key}"
+      export AWS_SESSION_TOKEN="${SMUGGLER_credstash_aws_session_token:-}"
+    fi
+    credstash \
+      -r ${SMUGGLER_credstash_region:-eu-west-1} \
+      ${SMUGGLER_credstash_table:+-t ${SMUGGLER_credstash_table}} \
+      list | sha1sum | cut -f 1 -d " " > ${SMUGGLER_OUTPUT_DIR}/versions
+
+  in: |
+    if [ "${SMUGGLER_credstash_aws_iam_profile:-}" != "true" ]; then
+      export AWS_ACCESS_KEY_ID="${SMUGGLER_credstash_aws_access_key_id}"
+      export AWS_SECRET_ACCESS_KEY="${SMUGGLER_credstash_aws_secret_access_key}"
+      export AWS_SESSION_TOKEN="${SMUGGLER_credstash_aws_session_token:-}"
+    fi
+
+    # Create the sh helpers
+    cat <<"EOF" > "${SMUGGLER_DESTINATION_DIR}/credstash.sh"
+    #/bin/sh
+    SCRIPT_PATH="$(dirname $0)"
+    EOF
+    chmod +x "${SMUGGLER_DESTINATION_DIR}/credstash.sh"
+    cp "${SMUGGLER_DESTINATION_DIR}/credstash.sh" "${SMUGGLER_DESTINATION_DIR}/credstash-terraform.sh"
+
+    for secret in $(echo "${SMUGGLER_secrets}" | jq -r '.[]' ); do
+      echo "INFO: Reading following secret: ${secret}"
+      mkdir -p "$(dirname "${SMUGGLER_DESTINATION_DIR}/${secret}")"
+      credstash \
+        -r ${SMUGGLER_credstash_region:-eu-west-1} \
+        ${SMUGGLER_credstash_table:+-t ${SMUGGLER_credstash_table}} \
+        get ${secret} > "${SMUGGLER_DESTINATION_DIR}/${secret}"
+      echo "echo export $(echo ${secret} | tr '.-' '__')=\"\\\$(cat \$SCRIPT_PATH/${secret})\"" >> "${SMUGGLER_DESTINATION_DIR}/credstash.sh"
+      echo "echo export $(echo TF_VAR_${secret} | tr '.-' '__')=\"\\\$(cat \$SCRIPT_PATH/${secret})\"" >> "${SMUGGLER_DESTINATION_DIR}/credstash-terraform.sh"
+    done
+  out: |
+    if [ "${SMUGGLER_credstash_aws_iam_profile:-}" != "true" ]; then
+      export AWS_ACCESS_KEY_ID="${SMUGGLER_credstash_aws_access_key_id}"
+      export AWS_SECRET_ACCESS_KEY="${SMUGGLER_credstash_aws_secret_access_key}"
+      export AWS_SESSION_TOKEN="${SMUGGLER_credstash_aws_session_token:-}"
+    fi
+
+    dir="$(echo "${SMUGGLER_SOURCES_DIR}/${SMUGGLER_secrets_dir}" | sed 's|//*|/|g;s|/$||')"
+    for secret_file in "${dir}"/*; do
+      secret="${secret_file##${dir}/}"
+      echo "INFO: Setting following secret: ${secret}"
+      credstash \
+        -r ${SMUGGLER_credstash_region:-eu-west-1} \
+        ${SMUGGLER_credstash_table:+-t ${SMUGGLER_credstash_table}} \
+        put \
+        ${SMUGGLER_credstash_key:+-k ${SMUGGLER_credstash_key}} \
+        -a \
+        "${secret}" "$(cat ${secret_file})"
+    done
+

--- a/examples/credstash_wrapper/Dockerfile.git-resource
+++ b/examples/credstash_wrapper/Dockerfile.git-resource
@@ -1,0 +1,18 @@
+FROM concourse/git-resource
+
+RUN mv /opt/resource/check /opt/resource/check.wrapped \
+    && mv /opt/resource/in /opt/resource/in.wrapped \
+    && mv /opt/resource/out /opt/resource/out.wrapped
+
+RUN mkdir -p /opt/resource/bin
+ADD ./assets/spruce /opt/resource/bin/
+ADD ./assets/unicreds /opt/resource/bin/
+ADD ./assets/smuggler /opt/resource/bin/
+
+ADD ./wrapper.sh /opt/resource/bin/
+
+RUN ln /opt/resource/bin/smuggler /opt/resource/check && \
+    ln /opt/resource/bin/smuggler /opt/resource/in && \
+    ln /opt/resource/bin/smuggler /opt/resource/out
+
+ADD ./smuggler.yml /opt/resource/

--- a/examples/credstash_wrapper/Dockerfile.s3-resource
+++ b/examples/credstash_wrapper/Dockerfile.s3-resource
@@ -1,0 +1,18 @@
+FROM concourse/s3-resource
+
+RUN mv /opt/resource/check /opt/resource/check.wrapped \
+    && mv /opt/resource/in /opt/resource/in.wrapped \
+    && mv /opt/resource/out /opt/resource/out.wrapped
+
+RUN mkdir -p /opt/resource/bin
+ADD ./assets/spruce /opt/resource/bin/
+ADD ./assets/unicreds /opt/resource/bin/
+ADD ./assets/smuggler /opt/resource/bin/
+
+ADD ./wrapper.sh /opt/resource/bin/
+
+RUN ln /opt/resource/bin/smuggler /opt/resource/check && \
+    ln /opt/resource/bin/smuggler /opt/resource/in && \
+    ln /opt/resource/bin/smuggler /opt/resource/out
+
+ADD ./smuggler.yml /opt/resource/

--- a/examples/credstash_wrapper/Makefile
+++ b/examples/credstash_wrapper/Makefile
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+DOCKER_HUB_ACCOUNT=redfactorlabs
+
+all: build push
+
+clean:
+	rm -rf assets
+
+assets/smuggler:
+	cd ../../ \
+	  && ./scripts/build
+	cp ../../assets/smuggler-linux-amd64 ./assets
+
+assets/unicreds:
+	mkdir -p assets
+	curl -Ls https://github.com/Versent/unicreds/releases/download/1.5.1/unicreds_1.5.1_linux_amd64.tar.gz | tar -xzf - -C ./assets
+	chmod +x ./assets/unicreds
+
+assets/spruce:
+	mkdir -p assets
+	curl -Ls https://github.com/geofffranks/spruce/releases/download/v1.8.15/spruce-linux-amd64 -o ./assets/spruce
+	chmod +x ./assets/spruce
+
+get_assets: assets/unicreds assets/smuggler assets/spruce
+
+build: get_assets
+	docker build . -f Dockerfile.git-resource -t $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-git-resource
+	docker build . -f Dockerfile.s3-resource -t $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-s3-resource
+	docker build . -f Dockerfile.semver-resource -t $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-semver-resource
+
+push:
+	docker push $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-git-resource
+	docker push $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-s3-resource
+	docker push $(DOCKER_HUB_ACCOUNT)/smuggler-credstash-semver-resource
+

--- a/examples/credstash_wrapper/README.md
+++ b/examples/credstash_wrapper/README.md
@@ -1,0 +1,118 @@
+# Example: credstash wrapper
+
+Proof of concept to add credential management to resources in concourse.
+
+This resource uses [smuggler concourse resource](https://github.com/redfactorlabs/concourse-smuggler-resource)
+to allow any other resource
+to retrieve variables from a [credstash store](https://github.com/fugue/credstash)
+
+It relies on [unicreds](https://github.com/Versent/unicreds) (golang credstash implementation)
+to retrieve all the variables from a credstash store, and [spruce](https://github.com/geofffranks/spruce)
+to expand the variables using the `(( grab $credential.name ))`.
+
+We use a basic shell script and static golang binaries, so this resource can be use for probably any resource.
+
+## Future work and limitations
+
+ * I will create a custom `docker_image` resource able to automatically path any docker image with a resource.
+
+ * Currently it uses [spruce and the spruce syntax](https://github.com/geofffranks/spruce), but in the future we might try
+   to implement a wrapper adhoc that simulates [the proposal from concourse devs](https://github.com/concourse/concourse/issues/291#issuecomment-233194564): `${credstash/a.random.key}`
+
+ * If you use `spruce` or `spiff` to render your manifest, you might have issues with this :)
+
+## Usage example
+
+You must first configure a [credstash store](https://github.com/fugue/credstash)
+using credstash, unicreds, or a [terraform configuration](https://github.com/keymon/tf-credstash).
+
+You must then populate the credstash store with variables:
+
+```
+unicreds \
+  -r eu-west-1 \
+  -t credstash-concourse-demo \
+  put-file \
+  -k alias/credstash-concourse-demo \
+  github.id_rsa \
+  ~/.ssh/concourse-demo
+```
+
+Define the new resource types:
+
+```
+resource_types:
+- name: smuggler-credstash-git
+  type: docker-image
+  source:
+    repository: redfactorlabs/smuggler-credstash-git-resource
+
+- name: smuggler-credstash-s3
+  type: docker-image
+  source:
+    repository: redfactorlabs/smuggler-credstash-s3-resource
+```
+
+> **NOTE:** If you are going to use this resources **I highly recommend** push your
+> own copy to your own docker repository. This image might change.
+
+And then define the resource, with these two kind of parameters:
+
+ 1. Credstash configuration:
+    * `credstash_table`: optional, credstash store dynamo table
+    * `credstash_region`: AWS region of the credstash store. Default: `eu-west-1`
+    * `credstash_aws_access_key_id`, `credstash_aws_secret_access_key` and `credstash_aws_session_token`: AWS credentials. Not needed when using IAM instance profiles
+    * `credstash_aws_iam_profile`: optional, use IAM instance profile (see below)
+
+ 2. The normal parameters of the resource, using a [syntax like in spruce](https://github.com/geofffranks/spruce).
+    For example: ```private_key: "(( grab $github.id_rsa ))"```
+
+For example:
+
+```yaml
+- name: project-git-iam-profile
+  type: smuggler-credstash-git
+  source:
+    credstash_aws_access_key_id: {{credstash_aws_access_key_id}}
+    credstash_aws_secret_access_key: {{credstash_aws_secret_access_key}}
+    credstash_aws_session_token: {{credstash_aws_session_token}}
+    credstash_table: concourse-demo
+    uri: git@github.com:/concourse-demo
+    private_key: "(( grab $github.id_rsa ))"
+
+```
+
+## Using credstash with IAM instance profiles
+
+One way of using this resource is [granting your Concourse workers with a IAM profile](https://bosh.io/docs/aws-iam-instance-profiles.html)
+that would allow access the credstash without having to pass any credentials at all to the pipelines.
+
+In this branch there is an example of how to configure the store and the profile: https://github.com/keymon/tf-credstash/tree/implement_iam_profile
+
+You only need to pass the option  `aws_iam_profile: true` as to the resource:
+
+```
+- name: project-git-iam-profile
+  type: smuggler-credstash-git
+  source:
+    aws_iam_profile: true
+    credstash_table: credstash-concourse-demo
+    uri: git@github.com:/concourse-demo
+    private_key: "(( grab $github.id_rsa ))"
+```
+
+## How does it work?
+
+This resources basically "intercepts" [the json request](https://concourse.ci/implementing-resources.html), and expands the variables in it with values from credstash.
+
+The implementation can be checked in:
+
+ * `Dockerfile.git-resource`: It gets the official image, renames the `check`, `in`, `out`, adds the binaries for `spruce`, `smuggler` and `unicreds` and the scripts.
+ * `smuggler.yml`: uses smuggler to simply delegate to the `wrapper.sh` for each command.
+ * `wrapper.sh`: Implements all the logic:
+  1. The json request from the stdin
+  2. Calls `unicreds exec` to retrieve the credentials, set them as environment variables and call `spruce`
+  3. `spruce merge`: would expand the environment variables of the json from stdin
+  4. `spruce json`: spruce reads json and spits yaml. This conversts back to json.
+
+

--- a/examples/credstash_wrapper/pipeline.yml
+++ b/examples/credstash_wrapper/pipeline.yml
@@ -1,0 +1,99 @@
+#
+# fly -t demo set-pipeline \
+#   -p smuggler-credstash-wrapper \
+#   -c pipeline.yml \
+#   --var "credstash_aws_access_key_id=${AWS_ACCESS_KEY_ID}" \
+#   --var "credstash_aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" \
+#   --var "credstash_aws_session_token=${AWS_SESSION_TOKEN}" \
+#   --var bucket-name=smuggler-test-bucket
+#
+---
+resource_types:
+- name: smuggler-credstash-git
+  type: docker-image
+  source:
+    repository: redfactorlabs/smuggler-credstash-git-resource
+
+- name: smuggler-credstash-s3
+  type: docker-image
+  source:
+    repository: redfactorlabs/smuggler-credstash-s3-resource
+
+resources:
+
+- name: project-git-creds
+  type: smuggler-credstash-git
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_aws_access_key_id: {{credstash_aws_access_key_id}}
+    credstash_aws_secret_access_key: {{credstash_aws_secret_access_key}}
+    credstash_aws_session_token: {{credstash_aws_session_token}}
+    uri: git@github.com:redfactorlabs/concourse-smuggler-resource
+    private_key: "(( grab $github.id_rsa ))"
+
+- name: project-git-iam-profile
+  type: smuggler-credstash-git
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_aws_iam_profile: true
+    uri: git@github.com:redfactorlabs/concourse-smuggler-resource
+    private_key: "(( grab $github.id_rsa ))"
+
+- name: project-s3-iam-profile
+  type: smuggler-credstash-git
+  source:
+    credstash_table: credstash-concourse-demo
+    credstash_aws_access_key_id: {{credstash_aws_access_key_id}}
+    credstash_aws_secret_access_key: {{credstash_aws_secret_access_key}}
+    credstash_aws_session_token: {{credstash_aws_session_token}}
+    access_key_id: "(( grab $aws.s3.access_key_id ))"
+    secret_access_key: "(( grab $aws.s3.secret_access_key ))"
+    bucket: {{bucket-name}}
+    versioned_file: data.tgz
+
+jobs:
+- name: test_job_git
+  serial: true
+  plan:
+  - get: project-git-creds
+  - get: project-git-iam-profile
+  - task: what_is_in_there
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+        - name: project-git-creds
+        - name: project-git-iam-profile
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            find .
+
+- name: test_job_s3
+  serial: true
+  plan:
+  - get: project-s3-iam-profile
+  - task: what_is_in_there
+    config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: alpine
+        inputs:
+        - name: project-s3-iam-profile
+        run:
+          path: sh
+          args:
+          - -e
+          - -c
+          - |
+            find .
+
+

--- a/examples/credstash_wrapper/smuggler.yml
+++ b/examples/credstash_wrapper/smuggler.yml
@@ -1,0 +1,4 @@
+commands:
+  check: /opt/resource/bin/wrapper.sh
+  in: /opt/resource/bin/wrapper.sh ${SMUGGLER_DESTINATION_DIR}
+  out: /opt/resource/bin/wrapper.sh ${SMUGGLER_SOURCES_DIR}

--- a/examples/credstash_wrapper/wrapper.sh
+++ b/examples/credstash_wrapper/wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+set -u
+
+SCRIPT_PATH="$(cd "$(dirname $0)"; pwd)"
+
+if [ "${SMUGGLER_credstash_aws_iam_profile:-}" != "true" ]; then
+	export AWS_ACCESS_KEY_ID="${SMUGGLER_credstash_aws_access_key_id}"
+	export AWS_SECRET_ACCESS_KEY="${SMUGGLER_credstash_aws_secret_access_key}"
+	export AWS_SESSION_TOKEN="${SMUGGLER_credstash_aws_session_token:-}"
+fi
+"${SCRIPT_PATH}"/unicreds \
+	-r ${SMUGGLER_credstash_region:-eu-west-1} \
+	${SMUGGLER_credstash_table:+-t ${SMUGGLER_credstash_table}} \
+	exec "${SCRIPT_PATH}"/spruce merge | \
+		"${SCRIPT_PATH}"/spruce json | \
+		/opt/resource/"${SMUGGLER_COMMAND}.wrapped" $@


### PR DESCRIPTION
This PR use smuggler and credstash to solve the credentials problem in concourse meanwhile they don't implement something upstream. See:
https://github.com/concourse/concourse/issues/291 and https://github.com/concourse/concourse/issues/545

In this PR we provide two resources:

smuggler-credstash-wrapper
--------------------------

New wrapper resource that would use credstash[1], a serverless credentials
store based on AWS DynamoDB and KMS and controlled by AWS credentials.

This resource uses smuggler concourse resource[2] to allow any other
resource to retrieve variables from a credstash store[1]

It relies on unicreds[3] (golang credstash implementation) to retrieve all
the variables from a credstash store, and spruce[4] to expand the variables
using the
`(( grab $credential.name ))` syntax

We use a basic shell script and static golang binaries, so this resource
can be use for probably any resource.

See README for details.

[1] https://github.com/fugue/credstash
[2] https://github.com/redfactorlabs/concourse-smuggler-resource
[3] https://github.com/Versent/unicreds
[4] https://github.com/geofffranks/spruce

smuggler-credstash
------------------

New resource that would use credstash[1], a serverless credentials store
based on AWS DynamoDB and KMS and controlled by AWS credentials.

It allows query values to later use in tasks and set values from tasks.

See README for details.

[1] https://github.com/fugue/credstash