### PR TITLE
Accept versions that are valid json as raw string

### DIFF
--- a/helpers/test/pipeline.go
+++ b/helpers/test/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"encoding/json"
+
 	"github.com/ghodss/yaml"
 
 	. "github.com/redfactorlabs/concourse-smuggler-resource/smuggler"
@@ -84,10 +85,7 @@ func (pipeline *Pipeline) JsonRequest(requestType RequestType, resource_name str
 	}
 
 	if requestType == InType || requestType == CheckType {
-		v, err := NewVersion(version)
-		if err != nil {
-			return "", fmt.Errorf("Failed encoding version %q: %+v", err, request)
-		}
+		v := NewVersion(version)
 		request.Version = *v
 	}
 

--- a/smuggler/models.go
+++ b/smuggler/models.go
@@ -135,33 +135,24 @@ func (v Version) ToString() string {
 	return string(b)
 }
 
-func NewVersion(s string) (*Version, error) {
+func NewVersion(s string) *Version {
 	var v Version
 
 	err := json.Unmarshal([]byte(s), &v)
 	if err != nil {
-		switch err.(type) {
-		case *json.SyntaxError:
-			v = make(Version)
-			v["ID"] = s
-		default:
-			return nil, err
-		}
+		v = make(Version)
+		v["ID"] = s
 	}
-	return &v, nil
+	return &v
 }
 
-func NewVersions(sl []string) ([]Version, error) {
+func NewVersions(sl []string) []Version {
 	var vs []Version
 	vs = make([]Version, 0, len(sl))
 	for _, s := range sl {
-		v, err := NewVersion(s)
-		if err != nil {
-			return vs, err
-		}
-		vs = append(vs, *v)
+		vs = append(vs, *NewVersion(s))
 	}
-	return vs, nil
+	return vs
 }
 
 type TaskParams struct {

--- a/smuggler/smuggler.go
+++ b/smuggler/smuggler.go
@@ -244,11 +244,7 @@ func readVersions(versionsFile string) ([]Version, error) {
 		return result, err
 	} else {
 		for _, l := range versionLines {
-			v, err := NewVersion(l)
-			if err != nil {
-				return result, err
-			}
-			result = append(result, *v)
+			result = append(result, *NewVersion(l))
 		}
 	}
 	return result, nil

--- a/smuggler/smuggler_test.go
+++ b/smuggler/smuggler_test.go
@@ -105,8 +105,7 @@ var _ = Describe("SmugglerCommand actions normal input-output", func() {
 				Ω(command.LastCommandOutput).Should(ContainSubstring("version=1.2.3"))
 			})
 			It("it returns versions as list of strings", func() {
-				vs, err := NewVersions([]string{"1.2.3", "1.2.4"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"1.2.3", "1.2.4"})
 				Ω(response.Versions).Should(BeEquivalentTo(vs))
 			})
 		})
@@ -170,8 +169,7 @@ var _ = Describe("SmugglerCommand actions stdin/stdout input-output", func() {
 				fixtureResourceName = "write_response_to_stdout"
 			})
 			It("it returns the version IDs", func() {
-				vs, err := NewVersions([]string{"3.2.1", "3.2.2"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"3.2.1", "3.2.2"})
 				Ω(response.Versions).Should(Equal(vs))
 			})
 			It("The stdout buffer is cleared", func() {
@@ -274,8 +272,7 @@ var _ = Describe("SmugglerCommand actions stdin/stdout input-output", func() {
 				Ω(response.Metadata).Should(BeEquivalentTo(vs))
 			})
 			It("it returns the version ID", func() {
-				v, err := NewVersion("3.2.1")
-				Ω(err).ShouldNot(HaveOccurred())
+				v := NewVersion("3.2.1")
 				Ω(response.Version).Should(Equal(*v))
 			})
 		})
@@ -326,8 +323,7 @@ var _ = Describe("SmugglerCommand params", func() {
 			Ω(m["complex_param"]).Should(MatchJSON(expectedJson))
 		})
 		It("should send the version param as a serialized json", func() {
-			v, err := NewVersion("someid")
-			Ω(err).ShouldNot(HaveOccurred())
+			v := NewVersion("someid")
 			Ω(response.Version).Should(BeEquivalentTo(*v))
 		})
 	})
@@ -483,8 +479,7 @@ func InOutCommonSmugglerTests() func() {
 				Ω(response.Metadata).Should(BeEquivalentTo(vs))
 			})
 			It("it returns the version ID", func() {
-				v, err := NewVersion("1.2.3")
-				Ω(err).ShouldNot(HaveOccurred())
+				v := NewVersion("1.2.3")
 				Ω(response.Version).Should(BeEquivalentTo(*v))
 			})
 		})

--- a/smuggler_test.go
+++ b/smuggler_test.go
@@ -88,8 +88,7 @@ var _ = Describe("smuggler commands", func() {
 				var response []Version
 				err := json.Unmarshal(session.Out.Contents(), &response)
 				Ω(err).ShouldNot(HaveOccurred())
-				vs, err := NewVersions([]string{"1.2.3", "1.2.4"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"1.2.3", "1.2.4"})
 				Ω(response).Should(BeEquivalentTo(vs))
 			})
 
@@ -214,8 +213,7 @@ var _ = Describe("smuggler commands", func() {
 				var response []Version
 				err := json.Unmarshal(session.Out.Contents(), &response)
 				Ω(err).ShouldNot(HaveOccurred())
-				vs, err := NewVersions([]string{"1.2.3", "1.2.4"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"1.2.3", "1.2.4"})
 				Ω(response).Should(BeEquivalentTo(vs))
 			})
 
@@ -245,8 +243,7 @@ var _ = Describe("smuggler commands", func() {
 				var response []Version
 				err := json.Unmarshal(session.Out.Contents(), &response)
 				Ω(err).ShouldNot(HaveOccurred())
-				vs, err := NewVersions([]string{"4.5.6", "4.5.7"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"4.5.6", "4.5.7"})
 				Ω(response).Should(BeEquivalentTo(vs))
 			})
 
@@ -269,8 +266,7 @@ var _ = Describe("smuggler commands", func() {
 				var response []Version
 				err := json.Unmarshal(session.Out.Contents(), &response)
 				Ω(err).ShouldNot(HaveOccurred())
-				vs, err := NewVersions([]string{"1.2.3", "1.2.4"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"1.2.3", "1.2.4"})
 				Ω(response).Should(BeEquivalentTo(vs))
 			})
 
@@ -294,8 +290,7 @@ var _ = Describe("smuggler commands", func() {
 				var response []Version
 				err := json.Unmarshal(session.Out.Contents(), &response)
 				Ω(err).ShouldNot(HaveOccurred())
-				vs, err := NewVersions([]string{"4.5.6", "4.5.7"})
-				Ω(err).ShouldNot(HaveOccurred())
+				vs := NewVersions([]string{"4.5.6", "4.5.7"})
 				Ω(response).Should(BeEquivalentTo(vs))
 			})
 
@@ -388,8 +383,7 @@ func InOutCommonSmugglerTests(session **gexec.Session) func() {
 			var response ResourceResponse
 			err := json.Unmarshal((*session).Out.Contents(), &response)
 			Ω(err).ShouldNot(HaveOccurred())
-			v, err := NewVersion("1.2.3")
-			Ω(err).ShouldNot(HaveOccurred())
+			v := NewVersion("1.2.3")
 			Ω(response.Version).Should(BeEquivalentTo(*v))
 		})
 		It("outputs a valid json with a version", func() {


### PR DESCRIPTION
When writing to ${SMUGGLER_OUTPUT_DIR}/versions, each line will
be parsed to check if it is a json with a type map[string]string.
If it is so, it will be directly used as the version struct,
otherwise the value would be wrapped in a hash: { "ID": "$val" }

But if the string is a valid json, but with a different type,
smuggler fails due a type missmatch.

That behaviour is incorrect. the line should the threated
as a raw string and also sbe wrapped in the hash.

In this commit NewVersion always success, and only decodes it as a
json if the line written in ${SMUGGLER_OUTPUT_DIR}/versions has
the format map[string]string, like:

    {
         "ref": "aaa",
         "branch": "master"
    }

There is no reason to return a error code, so we change the
signature and usages.