### PR TITLE
Log how the command is called with json input

### DIFF
--- a/helpers/utils/utils.go
+++ b/helpers/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -149,4 +151,13 @@ func MergeMaps(a, b interface{}) (interface{}, error) {
 		}
 	}
 	return m, nil
+}
+
+func JsonPrettyPrint(in []byte) []byte {
+	var out bytes.Buffer
+	err := json.Indent(&out, in, "", "  ")
+	if err != nil {
+		return in
+	}
+	return out.Bytes()
 }

--- a/smuggler/smuggler.go
+++ b/smuggler/smuggler.go
@@ -53,8 +53,10 @@ func (command *SmugglerCommand) Run(commandDefinition CommandDefinition, params 
 	}
 	params_env = append(params_env, os.Environ()...)
 
-	command.logger.Printf("[INFO] Running command:\n\tPath: '%s'\n\tArgs: '%s'\n\tEnv:\n\t'%s",
-		path, strings.Join(args, "' '"), strings.Join(params_env, "',\n\t'"))
+	command.logger.Printf(
+		"[INFO] Running command:\n\tPath: '%s'\n\tArgs: '%s'\n\tEnv:\n\t'%s'",
+		path, strings.Join(args, "' '"), strings.Join(params_env, "',\n\t'"),
+	)
 
 	command.lastCommand = exec.Command(path, args...)
 	command.lastCommand.Env = params_env

--- a/smuggler_test.go
+++ b/smuggler_test.go
@@ -321,7 +321,7 @@ var _ = Describe("smuggler commands", func() {
 				commandPath, jsonRequest = prepareCommandCheck("a_quiet_command")
 			})
 			It("There are no messages in Stderr", func() {
-				Ω(session.Err.Contents()).To(BeEmpty())
+				Ω(string(session.Err.Contents())).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
Log the command being called with the input json, in a format
that can be easily used to run from the container when
hijacking the container.

This would help troubleshooting issues developing resources with
smugger.

One drawback of this is that all the resource configuration would
be written to disk in the smuggler log.