### PR TITLE
Improve documentation in README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,19 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 FROM alpine:3.6
 
 # Add some stuff to your container
-RUN apk add --update bash \
+# Our base container will have some handy tooling
+ARG INSTALLED_PACKAGES="\
+    bash                \
+    zip                 \
+    curl                \
+    wget                \
+    openssl             \
+    ca-certificates     \
+    jq                  \
+    git                 \
+    openssh-client      \
+"
+RUN apk add --update ${INSTALLED_PACKAGES} \
     && rm -rf /var/cache/apk/*
 
 # Add the smuggler binary compiled previously
@@ -22,3 +34,6 @@ COPY --from=0 /go/bin/concourse-smuggler-resource /opt/resource/smuggler
 RUN ln /opt/resource/smuggler /opt/resource/check \
     && ln /opt/resource/smuggler /opt/resource/in \
     && ln /opt/resource/smuggler /opt/resource/out
+
+# Add a example default configuration of the commands
+ADD example-smuggler.yml /opt/resource/smuggler.yml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SMUGGLER_DOCKER_TAG:=ubuntu-14.04
+SMUGGLER_DOCKER_TAG:=alpine3.6
 SMUGGLER_DOCKER_REPOSITORY:=redfactorlabs/concourse-smuggler-resource
 SMUGGLER_DOCKER_IMAGE:=$(SMUGGLER_DOCKER_REPOSITORY):$(SMUGGLER_DOCKER_TAG)
 
@@ -27,7 +27,7 @@ assets/smuggler-linux-amd64: $(GO_FILES)
 		go build -o $@ .
 
 build-docker: test
-	docker build -t "${SMUGGLER_DOCKER_IMAGE}" .
+	docker build --no-cache -t "${SMUGGLER_DOCKER_IMAGE}" .
 
 push-docker: build-docker
 	docker push "${SMUGGLER_DOCKER_IMAGE}"

--- a/example-smuggler.yml
+++ b/example-smuggler.yml
@@ -1,0 +1,72 @@
+commands:
+  check: &common_script |
+    cat <<EOF 1>&2
+
+    Thank you for using smuggler!
+
+    NOTE: The current default implementation will just FAIL, in order
+          to print this message :). Define the '${SMUGGLER_COMMAND}' command.
+
+    The '${SMUGGLER_COMMAND}' command is not defined. You can define one this way:
+
+        - name: ${RESOURCE_NAME:-foo}
+          type: smuggler
+          source:
+            smuggler_debug: true # For debugging, remove later
+            commands:
+              ${SMUGGLER_COMMAND}: |
+                # Write here your logic
+                version="\$(curl -qs http://company.com/service | jq .a_value)"
+                echo "\${version}" > \${SMUGGLER_OUTPUT_DIR}/versions
+            param_1: value
+            param_2: value
+
+    Parameters would be passed as 'SMUGGLER_<param>' variables.
+    You currently have these variables available:
+
+    $(env | sed '/^PATH=/d;/^SHLVL=/d;/HOME=/d;/^_=/d;/^no_proxy=/d;/^USER=/d;/^PWD=/d;s/^/    /')
+
+    EOF
+
+    case ${SMUGGLER_COMMAND} in
+    check)
+      cat <<EOF 1>&2
+    To report back your versions found you can:
+      - write the versions as plaintext lines in \${SMUGGLER_OUTPUT_DIR}/versions
+      - write the metadata as key=value pairs in \${SMUGGLER_OUTPUT_DIR}/metadata
+      - or print a valid json as stdout as in https://concourse.ci/implementing-resources.html
+
+    EOF
+      ;;
+    in|out)
+      cat <<EOF 1>&2
+    To report back the new version and metadata you can:
+      - write the versions as plaintext lines in \${SMUGGLER_OUTPUT_DIR}/versions
+      - write the metadata as key=value pairs in \${SMUGGLER_OUTPUT_DIR}/metadata
+      - or print a valid json as stdout as in https://concourse.ci/implementing-resources.html
+
+    EOF
+    esac
+
+    case ${SMUGGLER_COMMAND} in
+    in)
+      cat <<EOF 1>&2
+    You can find the requested version in the variables \${SMUGGLER_VERSION_<key>}
+
+    Write the retrieved resource data into \${SMUGGLER_DESTINATION_DIR}
+
+    EOF
+      ;;
+    out)
+      cat <<EOF 1>&2
+    You can find the requested version in the variables \${SMUGGLER_VERSION_<key>}
+
+    Read the outputs from previous steps in the job from \${SMUGGLER_SOURCES_DIR}
+
+    EOF
+    esac
+
+    exit 1
+
+  in: *common_script
+  out: *common_script


### PR DESCRIPTION
Trying it more clear and more straightforward to know what smuggler is
about, with examples first and a more summarised reference of variables and
parameters.

We also add several useful tooling to the default container,
and we add some default implementation of the commands with a summary of the documentation, so that the users would get immediate feedback of how to use this stuff.

We finally fix the Makefile to build the example container with the right tag and ensure that it pulls the latest version of the code by using no-cache