### PR TITLE
Skip cleanup in deployment of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
 
 deploy:
   provider: releases
+  skip_cleanup: true
   file_glob: true
   file: "assets/smuggler-*-*"
   api_key:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # concourse-smuggler-resource: Concourse generic resource
 
 Smuggler is a *"generic-resource"*, that allows you to quickly
-implement any concourse eresource with minimum boilerplate, even
+implement any concourse resource with minimum boilerplate, even
 in the pipeline itself.
 
 It allows you to run any random command/script into the resource


### PR DESCRIPTION
We want to be able to upload the released binaries.